### PR TITLE
Fix warehouse products link

### DIFF
--- a/src/components/Product/MiniTabs.vue
+++ b/src/components/Product/MiniTabs.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       default: () => []
     },
     selectedId: {
-      type: Number,
+      type: [Number, String],
       default: null
     },
   },

--- a/src/pages/Products.vue
+++ b/src/pages/Products.vue
@@ -220,7 +220,7 @@ export default defineComponent({
     } = useProduct()
 
     const selectedSkladId = ref(
-      params?.skladId || ALL_TAB.id
+      params?.skladId || query?.sklad || ALL_TAB.id
     )
     const imagePreviewDialog = ref(false)
     const imagePreview = ref(null)

--- a/src/pages/SkladPage.vue
+++ b/src/pages/SkladPage.vue
@@ -102,7 +102,7 @@ const costsLink = computed(() => `/sklad/${params?.skladId}/costs`)
 const settingsLink = computed(() => `/sklad/${params?.skladId}/settings`)
 const productsWithMinSizesLink = computed(() => `/sklad/${params?.skladId}/products-with-min-sizes`)
 const categoriesLink = computed(() => `/sklad/${params?.skladId}/categories`)
-const productsLink = computed(() => `/sklad/${params?.skladId}/products`)
+const productsLink = computed(() => `/products?sklad=${params?.skladId}`)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Summary
- fix products link on warehouse page to use `/products?sklad=<id>`
- initialize Products page with `sklad` query parameter
- ensure Products page highlights the selected warehouse tab from the query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890eed98f2083309532f046442e583f