### PR TITLE
Fetch available sizes on mount

### DIFF
--- a/src/components/Dialogs/FilterDialog.vue
+++ b/src/components/Dialogs/FilterDialog.vue
@@ -241,7 +241,7 @@ watch(sklads, (value) => {
   if (value?.length) {
     fetchAvailableSizes()
   }
-})
+}, { immediate: true })
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Add `immediate: true` to the `sklads` watcher to ensure `fetchAvailableSizes` runs on initial component mount, preventing the available sizes filter from appearing empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3d64c32-34e9-406a-b5ca-b23fd41bbef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3d64c32-34e9-406a-b5ca-b23fd41bbef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

