### PR TITLE
Add translations for pages.deleteConfirmMessage

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -385,6 +385,7 @@ export default ({
     productsLabel: 'Products',
     countUnitsForSize: 'Number of units for size',
     typesLabel: 'Reports',
+    deleteConfirmMessage: 'When deleted, the selected products will be removed from the warehouse permanently',
   },
   mainSettings: {
     title: 'Main settings',

--- a/src/i18n/kg.js
+++ b/src/i18n/kg.js
@@ -385,6 +385,7 @@ export default ({
     productsLabel: 'Товарлар',
     countUnitsForSize: 'Өлчөм үчүн бирдик саны',
     typesLabel: 'Отчеттор',
+    deleteConfirmMessage: 'Өчүрүлгөндө тандалган товарлар складынан толук өчөт',
   },
   mainSettings: {
     title: 'Негизги баптоолор',

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -385,6 +385,7 @@ export default ({
     productsLabel: 'Товары',
     countUnitsForSize: 'Кол-во единиц для размера',
     typesLabel: 'Отчёты',
+    deleteConfirmMessage: 'При удалении выбранных товаров, они пропадут со склада навсегда',
   },
   mainSettings: {
     title: 'Основные Настройки',


### PR DESCRIPTION
Add translations for the `pages.deleteConfirmMessage` key to support internationalization.

---
<a href="https://cursor.com/background-agent?bcId=bc-c15eec1b-8f88-4300-b49c-661058a9476e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c15eec1b-8f88-4300-b49c-661058a9476e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

